### PR TITLE
fix udev 70-persistent-net.rules detection with Ubuntu chef/bento images. 

### DIFF
--- a/helper_scripts/apply_udev.py
+++ b/helper_scripts/apply_udev.py
@@ -184,6 +184,16 @@ def apply_remap():
     for line in output:
         print line
 
+"""
+In case user builds Ubuntu image less than 15.10 using chef/bento.
+Deletes directory created by chef/bento Packer build which messes up the
+apply_udev script.
+See  https://github.com/chef/bento/issues/592 for more details
+"""
+def delete_udev_dir(udev_file):
+    if os.path.isdir(udev_file):
+        os.rmdir(udev_file)
+
 def main():
 
     global verbose
@@ -204,6 +214,7 @@ def main():
     additions=[]
     removals=[]
 
+    delete_udev_dir(udev_file)
     args = parser.parse_args()
     if args.verbose: verbose=args.verbose
     if args.add:


### PR DESCRIPTION
Issue is partially fixed in [chef/bento Issue 592](https://github.com/chef/bento/issues/592). But thought it might be nice to have this in place in case someone doesn't realize its a bug in the packer build. Looks like its still enabled for 14.04 chef/bento images.. 

Error message I get without the fix is:
```
==> ubuntuvm: Traceback (most recent call last):
==> ubuntuvm:   File "/home/vagrant/apply_udev.py", line 237, in <module>
==> ubuntuvm:     
==> ubuntuvm: main()
==> ubuntuvm:   File "/home/vagrant/apply_udev.py", line 233, in main
==> ubuntuvm:     
==> ubuntuvm: for mac,interface in additions: add_rule(mac,interface)
==> ubuntuvm:   File "/home/vagrant/apply_udev.py", line 120, in add_rule
==> ubuntuvm:     
==> ubuntuvm: with open("/etc/udev/rules.d/70-persistent-net.rules","a") as udev_file:
==> ubuntuvm: IOError
==> ubuntuvm: : 
==> ubuntuvm: [Errno 21] Is a directory: '/etc/udev/rules.d/70-persistent-net.rules'
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.


```