### PR TITLE
Set default provider for libvirt

### DIFF
--- a/templates/Vagrantfile.j2
+++ b/templates/Vagrantfile.j2
@@ -14,6 +14,9 @@
 #            https://community.cumulusnetworks.com/cumulus/topics/converting-cumulus-vx-virtualbox-vagrant-box-gt-libvirt-vagrant-box
 #       -Start with \"vagrant up --provider=libvirt --no-parallel\n")
 
+#Set the default provider to libvirt in the case they forget --provider=libvirt or if someone destroys a machine it reverts to virtualbox
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'libvirt'
+
 # Check required plugins
 REQUIRED_PLUGINS_LIBVIRT = %w(vagrant-libvirt vagrant-mutate)
 exit unless REQUIRED_PLUGINS_LIBVIRT.all? do |plugin|


### PR DESCRIPTION
Add environment variable to set the default provider to libvirt if they build the topology with libvirt.  It avoids problems if you forget to manually set the provider.  Also helps if a user destroys the machine and then tries to recreate it will default back to Virtualbox.