### PR TITLE
Syntax modification to pass yaml linting

### DIFF
--- a/helper_scripts/fetch_udev_file.yml
+++ b/helper_scripts/fetch_udev_file.yml
@@ -1,3 +1,4 @@
+---
 - hosts: all
   remote_user: vagrant
   become_method: sudo
@@ -14,23 +15,28 @@
       become: no
 
     - name: collect udev file from host (so it can be restored later)
-      fetch: src=/etc/udev/rules.d/70-persistent-net.rules dest={{ destination_dir }}{{inventory_hostname}}/ flat=yes fail_on_missing=yes
+      fetch:
+        src=/etc/udev/rules.d/70-persistent-net.rules
+        dest={{ destination_dir }}{{inventory_hostname}}/ flat=yes
+        fail_on_missing=yes
 
-    - name: restart machine 
-      shell: sleep 2 && shutdown -r now "Ansible updates triggered" 
-      async: 1 
-      poll: 0 
-      become: yes 
-      ignore_errors: true 
+    - name: restart machine
+      shell: sleep 2 && shutdown -r now "Ansible updates triggered"
+      async: 1
+      poll: 0
+      become: yes
+      ignore_errors: true
 
     - name: waiting for server to come back after PXE boot
       become: no
-      local_action: 
-        module: wait_for 
+      local_action:
+        module: wait_for
         delay: 60
-        host: localhost 
+        host: localhost
         port: "{{ansible_ssh_port}}"
 
     - name: Replace udev rules file on the host
-      fetch: src={{destination_dir}}{{inventory_hostname}}/70-persistent-net.rules dest=/etc/udev/rules.d/70-persistent-net.rules
+      fetch:
+        src={{destination_dir}}{{inventory_hostname}}/70-persistent-net.rules
+        dest=/etc/udev/rules.d/70-persistent-net.rules
       become: yes


### PR DESCRIPTION
The following changes have been made to pass yaml linting standards:
"---" added to top of file
all trailing whitespace removed
all lines >80 characters broken up into multiple lines.