### PR TITLE
[v3] index exception with more than one fake node

### DIFF
--- a/topology_converter.py
+++ b/topology_converter.py
@@ -553,7 +553,8 @@ def clean_datastructure(devices):
         if 'function' in devices[i]:
             if devices[i]['function'] == 'fake':
                 indexes_to_remove.append(i)
-    for index in indexes_to_remove: del devices[index]
+    for index in sorted(indexes_to_remove, reverse=True):
+        del devices[index]
     return devices
 
 def remove_generated_files():


### PR DESCRIPTION
Addresses this traceback upon adding more than one fake node.

```
Traceback (most recent call last):
  File "topology_converter.py", line 703, in <module>
    main()
  File "topology_converter.py", line 692, in main
    devices=populate_data_structures(inventory)
  File "topology_converter.py", line 582, in populate_data_structures
    return clean_datastructure(devices)
  File "topology_converter.py", line 527, in clean_datastructure
    for index in indexes_to_remove: del devices[index]
IndexError: list assignment index out of range
```

Closes CumulusNetworks/topology_converter#20.