### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
 # Topology Converter
 =====================
 
-## Coming in v4.5.1
-* Colored output --> DONE
-* Investigate removing 2.5.x simulation measures --> DONE
-* Updated for Vagrant v1.8.6 and boxes that can specify their own username/password --> DONE
-* Added knob to avoid the Udev Remapping Operations for other boxes --> DONE
-* Removed dependency on Apply_udev.py --> DONE
-  * Did this to better support COREos and Fedora, cleaner overall solution
-* Investigate Ruby Vagrantfile Segmentation (based on yaml)
-
-
 
 ## See the [Documentation Section](./documentation) for way more information!
 
@@ -43,15 +33,16 @@ PRs are actively welcomed.
 3. Submit a PR on the Development Branch
 
 
-## New Features in v4.5.0
-This is a feature release:
-- Added [Create Management Network](documentation/auto_mgmt_network) option, this can automatically add a management network connected to eth0 port of all devices. Also builds a mgmt switch and ubuntu 1604 mgmt server.
-- Added a TOR and SuperSpine function group.
-- Added Group support for Ansible based on functions.
-- Fixed interface driver configuration in host images to use E1000 driver to allow getting link speed to setup bonds.
-- Corrected and enhanced documentation for new features and the "config" attribute.
+## New Features in v4.5.1
+* Added Colored output for easy reading
+* Removed 2.5.x simulation measures
+* Updated for Vagrant v1.8.6 and boxes that can specify their own username/password
+* Added knob to avoid the Udev Remapping Operations for other boxes
+* Removed dependency on Apply_udev.py
+  * Did this to better support COREos and Fedora, cleaner overall solution
 
 ## Changelog:
+* v4\.5\.1 2016\_10\_14: Added Colored output for easy reading. Removed 2.5.x simulation measures. Updated for Vagrant v1.8.6 and boxes that can specify their own username/password. Added knob to avoid the Udev Remapping Operations for other boxes. Removed dependency on Apply_udev.py; did this to better support COREos and Fedora, cleaner overall solution.
 * v4\.5\.0 2016\_09\_10: Added [Create Management Network](documentation/auto_mgmt_network) option, this can automatically add a management network connected to eth0 port of all devices. Also builds a mgmt switch and ubuntu 1604 mgmt server. Added a TOR and SuperSpine function group. Added Group support for Ansible based on functions. Fixed interface driver configuration in host images to use E1000 driver to allow getting link speed to setup bonds. Corrected and enhanced documentation for new features and the "config" attribute.
 * v4\.3\.1 2016\_08\_07: Bugfix to fix regression in handling libvirt topologies. 
 * v4\.3\.0 2016\_07\_29: Added Initial PXEboot for Libvirt Support. Deprecated ubuntu=true node attribute, it is handled automatically now for images with ubuntu in the name. Modified Functional Defaults to use Ubuntu 14.04 as the host default instead of ubuntu1604 for wider compatability. Fixed Broken Synced Folders flag. Fixed /root/.profile error message output on unsupported platforms. Added Error handling for use of incompatible Ubuntu 1604 images with Libvirt. Updated Example topologies for v4.3.0 supported attributes. Removed Reference Topology. Updated Documentation for Libvirt provider options.
@@ -86,5 +77,4 @@ This is a feature release:
 * Enhanced PXEBOOT Libvirt Support -- Blank OS value should be allowed
 * Null Audio Driver
 * os.path.abspath("./helper_scripts")
-* Apply Udev enhancement for IF index of vagrant interface (cleaner)
-
+* Investigate Ruby Vagrantfile Segmentation (based on yaml)

--- a/helper_scripts/oob_switch_config.sh
+++ b/helper_scripts/oob_switch_config.sh
@@ -23,7 +23,7 @@ iface swp\${i}
 
 auto bridge
 iface bridge inet dhcp
-    bridge-ports glob swp1-48 eth0
+    bridge-ports glob swp1-48
     bridge-stp on
 
 EOT

--- a/templates/Vagrantfile.j2
+++ b/templates/Vagrantfile.j2
@@ -90,7 +90,7 @@ Vagrant.configure("2") do |config|
 {% elif provider == 'libvirt' %}
   config.vm.provider :libvirt do |domain|
     # increase nic adapter count to be greater than 8 for all VMs.
-    domain.nic_adapter_count = 55{% endif %}
+    domain.nic_adapter_count = 130{% endif %}
   end
 
 {% if generate_ansible_hostfile == True %}

--- a/templates/Vagrantfile.j2
+++ b/templates/Vagrantfile.j2
@@ -120,7 +120,7 @@ Vagrant.configure("2") do |config|
     device.vm.box = "{{ device.os }}"{% if device.version %}
     device.vm.box_version = "{{ device.version }}"{% endif %}{% endif %}
 {% if provider == 'virtualbox' %}    device.vm.provider "virtualbox" do |v|
-      v.name = "{{ epoch_time }}_{{ device.hostname }}"{% elif provider == 'libvirt' %} 
+      v.name = "{{ epoch_time }}_{{ device.hostname }}"{% elif provider == 'libvirt' %}
     device.vm.provider :libvirt do |v|{% if device.pxehost=="True" %}
       v.storage :file, :size => '100G', :type => 'qcow2', :bus => 'sata', :device => 'sda'
       v.boot 'hd'
@@ -177,6 +177,7 @@ Vagrant.configure("2") do |config|
     device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/dhcpd.hosts", destination: "~/dhcpd.hosts"
     device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/hosts", destination: "~/hosts"
     device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/ansible_hostfile", destination: "~/ansible_hostfile"
+    device.vm.provision "file", source: "./helper_scripts/auto_mgmt_network/ztp_oob.sh", destination: "~/ztp_oob.sh"
 {% endif -%}
 {% if create_mgmt_network and device.function != "Unknown" and device.function != "oob-server" and device.function != "host" -%}
 
@@ -215,7 +216,7 @@ echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="{% if device.va
 echo "#### UDEV Rules (/etc/udev/rules.d/70-persistent-net.rules) ####"
 cat /etc/udev/rules.d/70-persistent-net.rules
 vagrant_interface_rule
-     
+
 {% endif -%}
 {% if device.playbook is defined -%}
     # Ansible Playbook Configuration
@@ -243,7 +244,7 @@ vagrant_interface_rule
     # NO REMAP APPLICATION Required
 
 {% else -%}
-    # Run Any Platform Specific Code and Apply the interface Re-map 
+    # Run Any Platform Specific Code and Apply the interface Re-map
     #   (may or may not perform a reboot depending on platform)
     device.vm.provision :shell , :inline => $script
 

--- a/templates/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh.j2
+++ b/templates/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh.j2
@@ -36,7 +36,7 @@ apt-get update -y
 
 echo " ### Installing Packages... ###"
 apt-get install -y htop isc-dhcp-server tree apache2 vlan git python-pip dnsmasq ifenslave apt-cacher-ng ansible python-dev sshpass lldpd libssl-dev
-pip install pip --upgrade 
+pip install pip --upgrade
 pip install setuptools --upgrade
 pip install ansible --upgrade
 modprobe 8021q
@@ -49,6 +49,9 @@ mv /home/$username/dhcpd.hosts /etc/dhcp/dhcpd.hosts
 chmod 755 -R /etc/dhcp/*
 systemctl restart isc-dhcp-server
 
+echo " ### Setting up ZTP ###"
+mv /home/$username/ztp_oob.sh /var/www/html/ztp_oob.sh
+
 echo " ### Setting Up Hostfile ###"
 mv /home/$username/hosts /etc/hosts
 
@@ -56,9 +59,31 @@ echo " ### Moving Ansible Hostfile into place ###"
 mkdir -p /etc/ansible
 mv /home/$username/ansible_hostfile /etc/ansible/hosts
 
+echo " ###Creating SSH keys for cumulus user ###"
+mkdir /home/cumulus/.ssh
+/usr/bin/ssh-keygen -b 2048 -t rsa -f /home/cumulus/.ssh/id_rsa -q -N ""
+chown cumulus /home/cumulus/.ssh/id_rsa.pub
+chown cumulus /home/cumulus/.ssh/id_rsa
+echo "Copying Key into /var/www/html..."
+cp /home/cumulus/.ssh/id_rsa.pub /var/www/html/authorized_keys
+
 chmod 777 -R /var/www/html/*
+
+echo " ### Creating turnup.sh script ###"
+REPOSITORY="https://github.com/CumulusNetworks/example"
+echo "git clone $REPOSITORY" > /home/cumulus/turnup.sh
+echo " ### creating .gitconfig for cumulus user"
+cat <<EOT >> /home/cumulus/.gitconfig
+[push]
+  default = matching
+[color]
+    ui = true
+[credential]
+    helper = cache --timeout=3600
+[core]
+    editor = vim
+EOT
 
 echo "############################################"
 echo "      DONE!"
 echo "############################################"
-

--- a/templates/auto_mgmt_network/ansible_hostfile.j2
+++ b/templates/auto_mgmt_network/ansible_hostfile.j2
@@ -8,6 +8,9 @@
 [exit]{% for device in devices %}{% if device.function == "exit" %}
 {{device.hostname}}{% if device.mgmt_ip is defined %} ansible_host={{device.mgmt_ip}}{% endif %} ansible_user=cumulus {% endif %}{% endfor %}
 
+[superspine]{% for device in devices %}{% if device.function == "superspine" %}
+{{device.hostname}}{% if device.mgmt_ip is defined %} ansible_host={{device.mgmt_ip}}{% endif %} ansible_user=cumulus {% endif %}{% endfor %}
+
 [spine]{% for device in devices %}{% if device.function == "spine" %}
 {{device.hostname}}{% if device.mgmt_ip is defined %} ansible_host={{device.mgmt_ip}}{% endif %} ansible_user=cumulus {% endif %}{% endfor %}
 

--- a/templates/auto_mgmt_network/ztp_oob.sh.j2
+++ b/templates/auto_mgmt_network/ztp_oob.sh.j2
@@ -1,0 +1,25 @@
+#!/bin/bash
+function error() {
+  echo -e "\e[0;33mERROR: The Zero Touch Provisioning script failed while running the command $BASH_COMMAND at line $BASH_LINENO.\e[0m" >&2
+}
+trap error ERR
+
+{% set mgmt_ips = devices[0].mgmt_ip.split(',') -%}
+
+SSH_URL="http://{{mgmt_ips[0]}}/authorized_keys"
+#Setup SSH key authentication for Ansible
+mkdir -p /home/cumulus/.ssh
+wget -O /home/cumulus/.ssh/authorized_keys $SSH_URL
+sed -i '/iface eth0/a \ vrf mgmt' /etc/network/interfaces
+cat <<EOT >> /etc/network/interfaces
+auto mgmt
+iface mgmt
+  address 127.0.0.1/8
+  vrf-table auto
+EOT
+
+echo "cumulus ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/10_cumulus
+
+reboot
+exit 0
+#CUMULUS-AUTOPROVISIONING

--- a/topology_converter.py
+++ b/topology_converter.py
@@ -429,7 +429,7 @@ def parse_topology(topology_file):
                 if provider=="virtualbox":
                     print "    %s:%s (mac: %s) --> %s:%s (mac: %s)     network_string:net%s" % (mgmt_switch,mgmt_switch_swp_val,left_mac,device,"eth0",right_mac,net_number)
                 elif provider=="libvirt":
-                    print "    %s:%s udp_port %s (mac: %s) --> %s:%s udp_port %s (mac: %s)" % (mgmt_switch,mgmt_switch_swp_val,left_mac,PortA,device,"eth0",PortB,right_mac)
+                    print "    %s:%s udp_port %s (mac: %s) --> %s:%s udp_port %s (mac: %s)" % (mgmt_switch,mgmt_switch_swp_val,PortA,left_mac,device,"eth0",PortB,right_mac)
 
                 add_link(inventory,
                          mgmt_switch,

--- a/topology_converter.py
+++ b/topology_converter.py
@@ -9,7 +9,7 @@
 #  hosted @ https://github.com/cumulusnetworks/topology_converter
 #
 #
-version = "4.5.1"
+version = "4.5.2_dev"
 
 
 import os

--- a/topology_converter.py
+++ b/topology_converter.py
@@ -9,7 +9,7 @@
 #  hosted @ https://github.com/cumulusnetworks/topology_converter
 #
 #
-version = "4.5.1_dev"
+version = "4.5.1"
 
 
 import os


### PR DESCRIPTION
The template creates ‘groups’ when using that particular ‘group’ type
(function).  This is achieved doing using loop.first

We also removed the ‘network’ group since its not used in the
jumpstart_template by Cumulus Networks consulting (primary consumer of
topology_converter).