### PR TITLE
Set the default shell to /bin/bash when creating the user "cumulus".

### DIFF
--- a/helper_scripts/extra_server_config.sh
+++ b/helper_scripts/extra_server_config.sh
@@ -5,7 +5,7 @@ echo "  Running Extra_Server_Config.sh"
 echo "#################################"
 sudo su
 
-useradd cumulus -m 
+useradd cumulus -m -s /bin/bash
 echo "cumulus:CumulusLinux!" | chpasswd
 
 #Test for Debian-Based Host


### PR DESCRIPTION
The default when creating a user with useradd is /bin/sh, set by /etc/defaults/useradd. The -s argument allows the default shell for a user to be set.