### PR TITLE
Add mgmt ip check

### DIFF
--- a/topology_converter.py
+++ b/topology_converter.py
@@ -865,7 +865,13 @@ def parse_topology(topology_file):
         for device in inventory:
 
             if 'mgmt_ip' in inventory[device]:
-                node_mgmt_ip = ipaddress.ip_address(unicode(inventory[device]['mgmt_ip']))
+                try:
+                    node_mgmt_ip = ipaddress.ip_address(unicode(inventory[device]['mgmt_ip']))
+
+                except:
+                    print(styles.FAIL + styles.BOLD + " ### ERROR: No IP specified in mgmt_ip option for %s" \
+                          % (device) + styles.ENDC)
+                    exit(1)
 
                 # Check that Defined Mgmt_IP is in same Subnet as OOB-SERVER
                 if node_mgmt_ip not in network:

--- a/topology_converter.py
+++ b/topology_converter.py
@@ -869,7 +869,7 @@ def parse_topology(topology_file):
                     node_mgmt_ip = ipaddress.ip_address(unicode(inventory[device]['mgmt_ip']))
 
                 except:
-                    print(styles.FAIL + styles.BOLD + " ### ERROR: No IP specified in mgmt_ip option for %s" \
+                    print(styles.FAIL + styles.BOLD + " ### ERROR: Invalid IP specified in mgmt_ip option for %s" \
                           % (device) + styles.ENDC)
                     exit(1)
 


### PR DESCRIPTION
Added a check if the mgmt_ip= option is used by an IP address is not supplied or is invalid.
```
"leaf39"   [function="leaf"  os="CumulusCommunity/cumulus-vx" version="3.6.1" mgmt_ip=""]

jaheller@farm18:~/topology_converter$ ./topology_converter.py -p libvirt -c -s 44000 topology.dot
.
.
.
### ERROR: No IP specified in mgmt_ip option for leaf39
```