### PR TITLE
add sudo to pip commands

### DIFF
--- a/templates/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh.j2
+++ b/templates/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh.j2
@@ -46,9 +46,9 @@ install_puppet(){
 install_ansible(){
     echo " ### Installing Ansible... ###"
     apt-get install -qy ansible sshpass libssh-dev python-dev libssl-dev libffi-dev
-    pip install pip --upgrade
-    pip install setuptools --upgrade
-    pip install ansible==$ansible_version --upgrade
+    sudo pip install pip --upgrade
+    sudo pip install setuptools --upgrade
+    sudo pip install ansible==$ansible_version --upgrade
 }
 
 ## MOTD


### PR DESCRIPTION
We found the pip commands were failing without sudo, so have added to the default script.