### PR TITLE
Generate paths to helper scripts from the working directory

### DIFF
--- a/templates/Vagrantfile.j2
+++ b/templates/Vagrantfile.j2
@@ -204,11 +204,11 @@ Vagrant.configure("2") do |config|
     {% endif -%}
 {% if device.function == "oob-server" and create_mgmt_device -%}
     # Copy over DHCP files and MGMT Network Files
-    device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/dhcpd.conf", destination: "~/dhcpd.conf"
-    device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/dhcpd.hosts", destination: "~/dhcpd.hosts"
-    device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/hosts", destination: "~/hosts"
-    device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/ansible_hostfile", destination: "~/ansible_hostfile"
-    device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/ztp_oob.sh", destination: "~/ztp_oob.sh"
+    device.vm.provision "file", source: "{{ mgmt_destination_dir }}dhcpd.conf", destination: "~/dhcpd.conf"
+    device.vm.provision "file", source: "{{ mgmt_destination_dir }}dhcpd.hosts", destination: "~/dhcpd.hosts"
+    device.vm.provision "file", source: "{{ mgmt_destination_dir }}hosts", destination: "~/hosts"
+    device.vm.provision "file", source: "{{ mgmt_destination_dir }}ansible_hostfile", destination: "~/ansible_hostfile"
+    device.vm.provision "file", source: "{{ mgmt_destination_dir }}ztp_oob.sh", destination: "~/ztp_oob.sh"
 {% endif -%}
 {% if create_mgmt_device and device.function != "Unknown" and device.function != "oob-server" and device.function != "host" -%}
 
@@ -220,7 +220,7 @@ Vagrant.configure("2") do |config|
 
 {% if device.function == "oob-switch" and create_mgmt_device %}
       # Transfer Bridge File
-      device.vm.provision "file", source: "{{ script_storage }}/auto_mgmt_network/bridge-untagged", destination: "~/bridge-untagged"
+      device.vm.provision "file", source: "{{ mgmt_destination_dir }}bridge-untagged", destination: "~/bridge-untagged"
 {% endif -%}
 
 {% if device.config is defined %}

--- a/topology_converter.py
+++ b/topology_converter.py
@@ -26,6 +26,7 @@ from operator import itemgetter
 
 pp = pprint.PrettyPrinter(depth=6)
 
+relpath_to_me = os.path.relpath(os.path.dirname(os.path.abspath(__file__)), os.getcwd())
 
 class styles:
     # Use these for text colors
@@ -127,7 +128,7 @@ synced_folder = False
 display_datastructures = False
 total_memory = 0
 VAGRANTFILE = 'Vagrantfile'
-VAGRANTFILE_template = 'templates/Vagrantfile.j2'
+VAGRANTFILE_template = relpath_to_me + '/templates/Vagrantfile.j2'
 customer = os.path.basename(os.path.dirname(os.getcwd()))
 TEMPLATES = [[VAGRANTFILE_template, VAGRANTFILE]]
 arg_string = " ".join(sys.argv)
@@ -191,7 +192,7 @@ dhcp_mac_file = "./dhcp_mac_map"
 ######################################################
 
 # Hardcoded Variables
-script_storage = "./helper_scripts"
+script_storage = relpath_to_me+"/helper_scripts"
 epoch_time = str(int(time.time()))
 mac_map = {}
 
@@ -722,8 +723,8 @@ def parse_topology(topology_file):
             inventory[mgmt_server]["memory"] = "512"
 
         if "config" not in inventory[mgmt_server]:
-            
-            inventory[mgmt_server]["config"] = script_storage+"/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh"
+            inventory[mgmt_server]["config"] = "./helper_scripts/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh"
+
         # Hardcode mgmt switch parameters
         if mgmt_switch is None and create_mgmt_network:
 
@@ -1224,8 +1225,8 @@ def render_jinja_templates(devices):
     # Render the MGMT Network stuff
     if create_mgmt_device:
         # Check that MGMT Template Dir exists
-        mgmt_template_dir = "./templates/auto_mgmt_network/"
-        if not os.path.isdir("./templates/auto_mgmt_network"):
+        mgmt_template_dir = relpath_to_me+"/templates/auto_mgmt_network/"
+        if not os.path.isdir(relpath_to_me+"/templates/auto_mgmt_network"):
             print(styles.FAIL + styles.BOLD +
                   "ERROR: " + mgmt_template_dir +
                   " does not exist. Cannot populate templates!" +
@@ -1246,7 +1247,7 @@ def render_jinja_templates(devices):
             print(mgmt_templates)
 
         # Create output location for MGMT template files
-        mgmt_destination_dir = script_storage+"/auto_mgmt_network/"
+        mgmt_destination_dir = "./helper_scripts/auto_mgmt_network/"
         if not os.path.isdir(mgmt_destination_dir):
             if verbose:
                 print("Making Directory for MGMT Helper Files: " + mgmt_destination_dir)
@@ -1280,7 +1281,7 @@ def render_jinja_templates(devices):
                                               topology_file=topology_file,
                                               arg_string=arg_string,
                                               epoch_time=epoch_time,
-                                              script_storage=script_storage,
+                                              mgmt_destination_dir=mgmt_destination_dir,
                                               generate_ansible_hostfile=generate_ansible_hostfile,
                                               create_mgmt_device=create_mgmt_device,
                                               function_group=function_group,
@@ -1308,7 +1309,7 @@ def render_jinja_templates(devices):
                                           topology_file=topology_file,
                                           arg_string=arg_string,
                                           epoch_time=epoch_time,
-                                          script_storage=script_storage,
+                                          mgmt_destination_dir=mgmt_destination_dir,
                                           generate_ansible_hostfile=generate_ansible_hostfile,
                                           create_mgmt_device=create_mgmt_device,
                                           function_group=function_group,

--- a/topology_converter.py
+++ b/topology_converter.py
@@ -393,17 +393,17 @@ def parse_topology(topology_file):
             if value == 'oob-switch':
                 inventory[node_name]['os'] = "CumulusCommunity/cumulus-vx"
                 inventory[node_name]['memory'] = "768"
-                inventory[node_name]['config'] = "./helper_scripts/oob_switch_config.sh"
+                inventory[node_name]['config'] = script_storage+"/oob_switch_config.sh"
 
             elif value in network_functions:
                 inventory[node_name]['os'] = "CumulusCommunity/cumulus-vx"
                 inventory[node_name]['memory'] = "768"
-                inventory[node_name]['config'] = "./helper_scripts/extra_switch_config.sh"
+                inventory[node_name]['config'] = script_storage+"/extra_switch_config.sh"
 
             elif value == 'host':
                 inventory[node_name]['os'] = "yk0/ubuntu-xenial"
                 inventory[node_name]['memory'] = "512"
-                inventory[node_name]['config'] = "./helper_scripts/extra_server_config.sh"
+                inventory[node_name]['config'] = script_storage+"/extra_server_config.sh"
 
         if provider == 'libvirt' and 'pxehost' in node_attr_list:
             if node.get('pxehost').replace('"', '') == "True":
@@ -722,8 +722,8 @@ def parse_topology(topology_file):
             inventory[mgmt_server]["memory"] = "512"
 
         if "config" not in inventory[mgmt_server]:
-            inventory[mgmt_server]["config"] = "./helper_scripts/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh"
             
+            inventory[mgmt_server]["config"] = script_storage+"/auto_mgmt_network/OOB_Server_Config_auto_mgmt.sh"
         # Hardcode mgmt switch parameters
         if mgmt_switch is None and create_mgmt_network:
 
@@ -745,7 +745,7 @@ def parse_topology(topology_file):
         if create_mgmt_network:
             inventory[mgmt_switch]["os"] = "CumulusCommunity/cumulus-vx"
             inventory[mgmt_switch]["memory"] = "512"
-            inventory[mgmt_switch]["config"] = "./helper_scripts/oob_switch_config.sh"
+            inventory[mgmt_switch]["config"] = script_storage+"/oob_switch_config.sh"
 
             # Add Link between oob-mgmt-switch oob-mgmt-server
             net_number += 1
@@ -778,7 +778,7 @@ def parse_topology(topology_file):
                     continue
                 elif inventory[device]["function"] in network_functions:
                     if "config" not in inventory[device]:
-                        inventory[device]["config"] = "./helper_scripts/extra_switch_config.sh"
+                        inventory[device]["config"] = script_storage+"/extra_switch_config.sh"
 
                 mgmt_switch_swp += 1
                 net_number += 1
@@ -1246,7 +1246,7 @@ def render_jinja_templates(devices):
             print(mgmt_templates)
 
         # Create output location for MGMT template files
-        mgmt_destination_dir = "./helper_scripts/auto_mgmt_network/"
+        mgmt_destination_dir = script_storage+"/auto_mgmt_network/"
         if not os.path.isdir(mgmt_destination_dir):
             if verbose:
                 print("Making Directory for MGMT Helper Files: " + mgmt_destination_dir)
@@ -1345,7 +1345,7 @@ def generate_ansible_files():
     if verbose:
         print("Generating Ansible Files...")
 
-    with open("./helper_scripts/empty_playbook.yml", "w") as playbook:
+    with open(script_storage+"/empty_playbook.yml", "w") as playbook:
         playbook.write("""---
 - hosts: all
   user: vagrant


### PR DESCRIPTION
Calculating the relative path from the current working directory to helper_scripts folder allows having the topology_converter to be stored centrally, with all topologies (Vagrantfiles) using the same set of helper_scripts. The functionality introduced with this PR will work only after PR #114 is merged.