### PR TITLE
Fix missing echo line terminator in Vagrantfile template

### DIFF
--- a/templates/Vagrantfile.j2
+++ b/templates/Vagrantfile.j2
@@ -97,7 +97,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             ls -lha /var/lib/cumulus/ztp/cumulus-ztp
 
             if [ -z /tmp/cumulus-ztp ]; then
-                echo "  ### Found ZTP Script, moving into preload directory...
+                echo "  ### Found ZTP Script, moving into preload directory... ###"
                 mv /tmp/cumulus-ztp /var/lib/cumulus/ztp/cumulus-ztp
                 chmod +x /var/lib/cumulus/ztp/cumulus-ztp
                 ls -lha /var/lib/cumulus/ztp/cumulus-ztp

--- a/templates/Vagrantfile.j2
+++ b/templates/Vagrantfile.j2
@@ -91,10 +91,6 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "### Resetting ZTP to work next boot..."
             ztp -R 2>&1
             ztp -i 2>&1
-            ls -lha /tmp/cumulus-ztp
-            mv /tmp/cumulus-ztp /var/lib/cumulus/ztp/cumulus-ztp
-            chmod +x /var/lib/cumulus/ztp/cumulus-ztp
-            ls -lha /var/lib/cumulus/ztp/cumulus-ztp
 
             if [ -z /tmp/cumulus-ztp ]; then
                 echo "  ### Found ZTP Script, moving into preload directory... ###"


### PR DESCRIPTION
The closing double quote is missing causing the script to fail
Also, cumulus-ztp file is processed twice (mv) causing errors